### PR TITLE
Fix crash when API time is missing

### DIFF
--- a/app/src/main/java/com/example/androidweather/MainActivity.kt
+++ b/app/src/main/java/com/example/androidweather/MainActivity.kt
@@ -28,12 +28,18 @@ class MainActivity : AppCompatActivity() {
 
         val call = service.getWeatherData()
 
-        fun formatDateTime(inputDateTime: String): String {
+        fun formatDateTime(inputDateTime: String?): String {
+            if (inputDateTime.isNullOrBlank()) return ""
+
             val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.getDefault())
             val outputFormat = SimpleDateFormat("dd.MM.yyyy HH:mm", Locale.getDefault())
 
-            val date = inputFormat.parse(inputDateTime)
-            return outputFormat.format(date)
+            return try {
+                val date = inputFormat.parse(inputDateTime)
+                outputFormat.format(date)
+            } catch (ex: Exception) {
+                ""
+            }
         }
 
         call.enqueue(object : Callback<WeatherNow> {
@@ -50,7 +56,7 @@ class MainActivity : AppCompatActivity() {
 
 
                         currentTemperatureTextView.text = tempnow.toString() + "°"
-                        currentDate.text = formatDateTime(timenow.toString())
+                        currentDate.text = formatDateTime(timenow)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid crash in `formatDateTime` when the API time is null or malformed
- call `formatDateTime` with the nullable string directly

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6857b57882a88331886cd506548da2d8